### PR TITLE
fix: JSON.parse errors for validations in export.test

### DIFF
--- a/test/commands/Export.test.js
+++ b/test/commands/Export.test.js
@@ -3,6 +3,8 @@ const MemoryStorage = require('../../src/utilities/FileSnapshot/MemoryStorage.js
 const Export = require('../../src/commands/alias/Export')
 const FileUtil = require('../../src/utilities/FileUtility')
 const fs = require('fs');
+const FilesystemStorage = require('../../src/utilities/FileSnapshot/FilesystemStorage')
+
 
 
 describe('Tests for exporting alias', () => {
@@ -11,29 +13,29 @@ describe('Tests for exporting alias', () => {
 
         describe('Exporting an empty file', () => {
             test
-            .stdout()
-            .stub(Export, 'storage', new MemoryStorage({  }, false))
-            .stub(FileUtil, 'storage', new MemoryStorage({  }, false))
-            .command(['alias:Export'])
-            .it('should throw chalk error', async ctx => {
-                expect(await FileUtil.storage.load()).to.eql({
-                    
+                .stdout()
+                .stub(Export, 'storage', new MemoryStorage({}, false))
+                .stub(FileUtil, 'storage', new MemoryStorage({}, false))
+                .command(['alias:Export'])
+                .it('should throw chalk error', async ctx => {
+                    expect(await FileUtil.storage.load()).to.eql({
+
+                    })
                 })
-            })
         })
 
         describe('Exporting with extra arguments', () => {
             test
-            .stdout()
-            .stub(Export, 'storage', new MemoryStorage({  }, false))
-            .stub(FileUtil, 'storage', new MemoryStorage({  }, false))
-            .command(['alias:Export', 'alist'])
-            .it('extra arguments passed for export', async ctx => {
-                expect(await FileUtil.storage.load()).to.eql({
-                    
+                .stdout()
+                .stub(Export, 'storage', new MemoryStorage({}, false))
+                .stub(FileUtil, 'storage', new MemoryStorage({}, false))
+                .command(['alias:Export', 'alist'])
+                .it('extra arguments passed for export', async ctx => {
+                    expect(await FileUtil.storage.load()).to.eql({
+
+                    })
+                    expect(ctx.stdout).to.contain("Invalid argument 'alist' provided");
                 })
-                expect(ctx.stdout).to.contain("Invalid argument 'alist' provided");
-            })
         })
 
     })
@@ -42,15 +44,14 @@ describe('Tests for exporting alias', () => {
     describe('After Setup', () => {
 
         describe('Exporting an empty file', () => {
-            
+
             const filename = 'dataexport.json';
             const path = process.cwd() + '/' + filename;
 
             before(async function () {
 
-                fs.open(path, 'w',  err => {
-                    if (err) 
-                    {
+                fs.open(path, 'w', err => {
+                    if (err) {
                         console.log(err);
                         return;
                     }
@@ -58,25 +59,27 @@ describe('Tests for exporting alias', () => {
             });
 
             test
-            .stdout()
-            .stub(Export, 'storage', new MemoryStorage({  }))
-            .stub(FileUtil, 'storage', new MemoryStorage({  } ))
-            .command(['alias:Export'])
-            .it('export empty file', async ctx => {
-                expect(await FileUtil.storage.load()).to.eql({
-                    
+                .stdout()
+                .stub(Export, 'storage', new MemoryStorage({}))
+                .stub(FileUtil, 'storage', new MemoryStorage({}))
+                .command(['alias:Export'])
+                .it('export empty file', async ctx => {
+                    expect(await FileUtil.storage.load()).to.eql({
+
+                    })
+                    expect(ctx.stdout).to.contain("Export Completed");
+
+                    const fileStorage = new FilesystemStorage();
+                    const db = await fileStorage.load(path);
+                    expect(db).to.be.a('object');
+                    expect(Object.entries(db).length).to.equal(0);
+
                 })
-                expect(ctx.stdout).to.contain("Export Completed");
-                
-                // var data = JSON.parse(fs.readFileSync(path).toString());
-                // expect(data).to.eql({});
-            })
 
             after(async function () {
 
                 fs.unlink(path, err => {
-                    if (err) 
-                    {
+                    if (err) {
                         console.log(err);
                         return;
                     }
@@ -91,9 +94,8 @@ describe('Tests for exporting alias', () => {
 
             before(async function () {
 
-                fs.open(path, 'w',  err => {
-                    if (err) 
-                    {
+                fs.open(path, 'w', err => {
+                    if (err) {
                         console.log(err);
                         return;
                     }
@@ -101,29 +103,30 @@ describe('Tests for exporting alias', () => {
             });
 
             test
-            .stdout()
-            .stub(Export, 'storage', new MemoryStorage({ hello: "world", hello1: "world2" }))
-            .stub(FileUtil, 'storage', new MemoryStorage({ hello: "world", hello1: "world2" } ))
-            .command(['alias:Export'])
-            .it('export filled file', async ctx => {
-                expect(await FileUtil.storage.load()).to.eql({
-                    hello: "world", 
-                    hello1: "world2"
+                .stdout()
+                .stub(Export, 'storage', new MemoryStorage({ hello: "world", hello1: "world2" }))
+                .stub(FileUtil, 'storage', new MemoryStorage({ hello: "world", hello1: "world2" }))
+                .command(['alias:Export'])
+                .it('export filled file', async ctx => {
+                    expect(await FileUtil.storage.load()).to.eql({
+                        hello: "world",
+                        hello1: "world2"
+                    })
+                    expect(ctx.stdout).to.contain("Export Completed");
+                    const fileStorage = new FilesystemStorage();
+                    const db = await fileStorage.load(path);
+                    expect(db).to.be.a('object');
+                    expect(Object.entries(db).length).to.not.equal(0);
+
+                    expect(Object.entries(db)[0].toString).to.equal(['hello', 'world'].toString);
+                    expect(Object.entries(db)[1].toString).to.equal(['hello1', 'world2'].toString);
+
                 })
-                expect(ctx.stdout).to.contain("Export Completed");
-                
-                // var data = JSON.parse(fs.readFileSync(path).toString());
-                // expect(data).to.eql({
-                //     hello: "world", 
-                //     hello1: "world2"
-                // });
-            })
 
             after(async function () {
 
                 fs.unlink(path, err => {
-                    if (err) 
-                    {
+                    if (err) {
                         console.log(err);
                         return;
                     }
@@ -133,16 +136,16 @@ describe('Tests for exporting alias', () => {
 
         describe('Exporting with extra arguments', () => {
             test
-            .stdout()
-            .stub(Export, 'storage', new MemoryStorage({  }))
-            .stub(FileUtil, 'storage', new MemoryStorage({  } ))
-            .command(['alias:Export', 'alist'])
-            .it('extra arguments passed for export', async ctx => {
-                expect(await FileUtil.storage.load()).to.eql({
-                    
+                .stdout()
+                .stub(Export, 'storage', new MemoryStorage({}))
+                .stub(FileUtil, 'storage', new MemoryStorage({}))
+                .command(['alias:Export', 'alist'])
+                .it('extra arguments passed for export', async ctx => {
+                    expect(await FileUtil.storage.load()).to.eql({
+
+                    })
+                    expect(ctx.stdout).to.contain("Invalid argument 'alist' provided");
                 })
-                expect(ctx.stdout).to.contain("Invalid argument 'alist' provided");
-            })
         })
 
     })


### PR DESCRIPTION
# Description:
Load the export files using FileSnapshot and not JSON.parser to avoid string \n errors

Fixes #70

## Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

 
# Checklist:
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
